### PR TITLE
small delay before changing windows

### DIFF
--- a/src/components/recipe/RecipeDelete.js
+++ b/src/components/recipe/RecipeDelete.js
@@ -5,16 +5,21 @@ import { ExclamationIcon } from "@heroicons/react/outline";
 
 import { deleteRecipe } from "../../redux/actions/recipes";
 
-export default function Logout({ modal, setModal, id }) {
+export default function RecipeDelete({ modal, setModal, id }) {
   const cancelButtonRef = useRef(null);
 
   const dispatch = useDispatch();
 
   const handleDeleteClick = () => {
     dispatch(deleteRecipe(id));
-    window.location = "/";
+    changeWindow();
   };
 
+  async function changeWindow(){
+    await new Promise (res => setTimeout(res, 100));
+    window.location = "/";
+  }
+ 
   return (
     <Transition.Root show={modal} as={Fragment}>
       <Dialog


### PR DESCRIPTION
Added a small delay before switching window to "/". Ran into the same issue with create, the window would change before the dispatch() finished executing. Also functions name was Logout? Not sure if that was left that way intentionally but changed it to RecipeDelete just in case..